### PR TITLE
feat: add match negation for charset expect

### DIFF
--- a/include/parsi/charset.hpp
+++ b/include/parsi/charset.hpp
@@ -16,7 +16,9 @@ class Charset {
     internal::Bitset<256> _map;
 
 public:
-    constexpr Charset() noexcept {}
+    constexpr Charset() noexcept
+    {
+    }
 
     constexpr explicit Charset(const char* charset) noexcept
     {
@@ -68,13 +70,24 @@ public:
         return ret;
     }
 
-    [[nodiscard]] friend constexpr auto operator+(const parsi::Charset& lhs, const parsi::Charset& rhs) noexcept -> Charset
+    /** make a charset that matches any character except the currently set characters. */
+    [[nodiscard]] constexpr auto opposite() const noexcept -> Charset
+    {
+        Charset ret = *this;
+        ret._map = ret._map.negated();
+        return ret;
+    }
+
+    [[nodiscard]] friend constexpr auto operator+(const parsi::Charset& lhs,
+                                                  const parsi::Charset& rhs) noexcept -> Charset
     {
         return lhs.joined(rhs);
     }
 
-    [[nodiscard]] friend constexpr bool operator==(const parsi::Charset&, const parsi::Charset&) noexcept = default;
-    [[nodiscard]] friend constexpr bool operator!=(const parsi::Charset&, const parsi::Charset&) noexcept = default;
+    [[nodiscard]] friend constexpr bool operator==(const parsi::Charset&,
+                                                   const parsi::Charset&) noexcept = default;
+    [[nodiscard]] friend constexpr bool operator!=(const parsi::Charset&,
+                                                   const parsi::Charset&) noexcept = default;
 };
 
 }  // namespace parsi

--- a/include/parsi/fn/expect.hpp
+++ b/include/parsi/fn/expect.hpp
@@ -12,16 +12,13 @@ namespace fn {
  */
 struct ExpectChar {
     char expected;
+    bool negate = false;
 
     [[nodiscard]] constexpr auto operator()(Stream stream) const noexcept -> Result
     {
-        if (!stream.starts_with(expected)) {
-            return Result{stream, false};
-        }
-
-        stream.advance(1);
-
-        return Result{stream, true};
+        const bool is_valid = negate ^ stream.starts_with(expected);
+        stream.advance(is_valid);
+        return Result{stream, is_valid};
     }
 };
 
@@ -82,6 +79,15 @@ struct ExpectString {
 }
 
 /**
+ * Creates a parser that expects the stream to start with the given character.
+ */
+[[nodiscard]] constexpr auto expect_not(char expected) noexcept
+    -> fn::ExpectChar
+{
+    return fn::ExpectChar{ .expected = expected, .negate = true };
+}
+
+/**
  * Creates a parser that expects the stream to
  * start with a character the is in the given charset.
  */
@@ -89,6 +95,16 @@ struct ExpectString {
     -> fn::ExpectCharset
 {
     return fn::ExpectCharset{expected};
+}
+
+/**
+ * Creates a parser that expects the stream to
+ * start with a character the is in the given charset.
+ */
+[[nodiscard]] constexpr auto expect_not(Charset expected) noexcept
+    -> fn::ExpectCharset
+{
+    return fn::ExpectCharset{expected.opposite()};
 }
 
 }  // namespace parsi

--- a/include/parsi/internal/bitset.hpp
+++ b/include/parsi/internal/bitset.hpp
@@ -18,7 +18,7 @@ class Bitset {
     using primary_type = std::size_t;
 
     constexpr static std::size_t k_cell_bitcount = sizeof(primary_type) * 8;
-    constexpr static std::size_t k_array_size = std::max(N / k_cell_bitcount, k_cell_bitcount);
+    constexpr static std::size_t k_array_size = N / k_cell_bitcount + (N % k_cell_bitcount != 0);
 
     std::array<primary_type, k_array_size> _bytes = {0};
 
@@ -85,6 +85,26 @@ public:
         bitset.set(other);
 
         return bitset;
+    }
+    
+    /** bit flips all the set bits to false and all the not set bits to true. */
+    constexpr void negate() noexcept
+    {
+        // NOTE: it also negates the out of bounds bits
+        //       at the last cell which its bit count exceed `N`.
+        //       it shouldn't be a problem as long as `test` method
+        //       checks for `index >= N` and always returns false for that case.
+        for (auto& cell : _bytes) {
+            cell = ~cell;
+        }
+    }
+
+    /** bit flips all the set bits to false and all the not set bits to true. */
+    [[nodiscard]] constexpr auto negated() const noexcept -> Bitset
+    {
+        Bitset ret = *this;
+        ret.negate();
+        return ret;
     }
 
     template <std::size_t M>

--- a/tests/bitset.cpp
+++ b/tests/bitset.cpp
@@ -93,4 +93,39 @@ TEST_CASE("Bitset")
 
         CHECK(joined_bitset == bitset_b.joined(bitset_a));
     }
+
+    SECTION("negated bits")
+    {
+        auto bitset = parsi::internal::Bitset<64>{};
+        bitset.set(0, true);
+        bitset.set(1, true);
+        bitset.set(42, true);
+
+        auto bitset_negated = bitset.negated();
+
+        CHECK(!bitset_negated.test(0));
+        CHECK(!bitset_negated.test(1));
+        CHECK(!bitset_negated.test(42));
+
+        CHECK(bitset_negated.test(2));
+        CHECK(bitset_negated.test(3));
+        CHECK(bitset_negated.test(5));
+        CHECK(bitset_negated.test(10));
+        CHECK(bitset_negated.test(43));
+        CHECK(bitset_negated.test(53));
+        CHECK(bitset_negated.test(63));
+    }
+
+    SECTION("negate in-place modifier")
+    {
+        auto bitset = parsi::internal::Bitset<64>{};
+        bitset.set(0, true);
+        bitset.set(1, true);
+        bitset.set(42, true);
+
+        auto bitset_copy_negate = bitset;
+        bitset_copy_negate.negate();
+
+        CHECK(bitset.negated() == bitset_copy_negate);
+    }
 }

--- a/tests/charset.cpp
+++ b/tests/charset.cpp
@@ -71,3 +71,31 @@ TEST_CASE("Charset-Combination")
         CHECK(numeric.joined(lowercase).joined(uppercase) == alphanumeric);
     }
 }
+
+TEST_CASE("Charset-Opposite")
+{
+    // constexpr auto non_numeric = parsi::Charset("0123456789").opposite();
+    
+    auto numeric = parsi::Charset("0123456789");
+    auto non_numeric = numeric.opposite();
+
+    CHECK(numeric != non_numeric);
+
+    CHECK(!non_numeric.contains('0'));
+    CHECK(!non_numeric.contains('1'));
+    CHECK(!non_numeric.contains('2'));
+    CHECK(!non_numeric.contains('3'));
+    CHECK(!non_numeric.contains('4'));
+    CHECK(!non_numeric.contains('5'));
+    CHECK(!non_numeric.contains('6'));
+    CHECK(!non_numeric.contains('7'));
+    CHECK(!non_numeric.contains('8'));
+    CHECK(!non_numeric.contains('9'));
+
+    CHECK(non_numeric.contains('\0'));
+    CHECK(non_numeric.contains('A'));
+    CHECK(non_numeric.contains('@'));
+    CHECK(non_numeric.contains('\n'));
+    CHECK(non_numeric.contains('\r'));
+    CHECK(non_numeric.contains('\255'));
+}

--- a/tests/parsers.cpp
+++ b/tests/parsers.cpp
@@ -28,6 +28,19 @@ TEST_CASE("expect")
     CHECK(not pr::expect(pr::Charset("abcd"))("h"));
 }
 
+TEST_CASE("expect_not")
+{
+    CHECK(pr::expect_not('a')("ba"));
+    CHECK(not pr::expect_not('a')("ab"));
+
+    CHECK(pr::expect_not(pr::Charset("abcd"))("A"));
+    CHECK(pr::expect_not(pr::Charset("abcd"))("@"));
+    CHECK(not pr::expect_not(pr::Charset("abcd"))("a"));
+    CHECK(not pr::expect_not(pr::Charset("abcd"))("b"));
+    CHECK(not pr::expect_not(pr::Charset("abcd"))("c"));
+    CHECK(not pr::expect_not(pr::Charset("abcd"))("d"));
+}
+
 TEST_CASE("eos")
 {
     CHECK(pr::eos()(""));


### PR DESCRIPTION
This PR solves the problems stated in issue #42, but with a different solution that the one suggested in the issue.

Changes:
 - Add `Charset::opposite` to support negation on charset.
 - Add `expect_not` for `char` with `bool parsi::fn::ExpectChar::negate` member variable which when `negate` is true, then it will match any character except the given `char parsi::fn::ExpectChar::expected`.
 - Add `expect_not` for `Charset` which will pass the `charset.opposite()` to the `parsi::fn::ExpectCharset`, which will match any other character than specified originally in the `charset` parameter.