### PR TITLE
ci: disable build docs job temporarily

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -65,21 +65,23 @@ jobs:
       - name: Codecov
         uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{secrets.CODECOV_TOKEN}}
           files: build/${{matrix.config.preset}}/coverage/coverage.xml
           fail_ci_if_error: true
           functionalities: fix
 
       - name: Build Docs
+        if: false
         run: |
           cmake --build --preset ${{matrix.config.preset}} --target docs
           mv build/${{matrix.config.preset}}/docs/sphinx _site
 
       - name: Upload Pages Artifacts
+        if: false
         uses: actions/upload-pages-artifact@v2
 
   deploy-docs:
-    if: success() && github.ref == 'refs/heads/main'
+    if: false && success() && github.ref == 'refs/heads/main'
     needs: build-test-docs
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The dependencies required to build the docs weren't version pinned, and currently they're updated at upstream. causing the build to fail for an unknown reason.

Other branches in development require the ci to be working properly, and thus disabling them for now until the root problem is figured out, the dependencies are pinned, and the ci is fixed.