### PR TITLE
feat: add char range set parser

### DIFF
--- a/include/parsi/charset.hpp
+++ b/include/parsi/charset.hpp
@@ -8,6 +8,11 @@
 
 namespace parsi {
 
+struct CharRange {
+    char begin;
+    char end;
+};
+
 /**
  * A container to hold a charset
  * and check whether a character/byte is in the set.

--- a/include/parsi/fn/anyof.hpp
+++ b/include/parsi/fn/anyof.hpp
@@ -47,7 +47,7 @@ private:
             if (res) [[likely]] {
                 return res;
             }
-            return parse_rec<I+1>(res.stream);
+            return parse_rec<I+1>(stream);
         }
     }
 };

--- a/include/parsi/fn/eos.hpp
+++ b/include/parsi/fn/eos.hpp
@@ -13,11 +13,7 @@ namespace fn {
 struct Eos {
     [[nodiscard]] constexpr auto operator()(Stream stream) const noexcept -> Result
     {
-        if (stream.size() > 0) {
-            return Result{stream, false};
-        }
-
-        return Result{stream, true};
+        return Result{stream, stream.size() <= 0};
     };
 };
 

--- a/tests/parsers.cpp
+++ b/tests/parsers.cpp
@@ -30,9 +30,20 @@ TEST_CASE("expect")
     CHECK(not pr::expect(pr::Charset("abcd"))("g"));
     CHECK(not pr::expect(pr::Charset("abcd"))("h"));
 
+    CHECK(pr::expect(pr::CharRange{'a', 'd'})("a"));
+    CHECK(pr::expect(pr::CharRange{'a', 'd'})("b"));
+    CHECK(pr::expect(pr::CharRange{'a', 'd'})("c"));
+    CHECK(pr::expect(pr::CharRange{'a', 'd'})("d"));
+
+    CHECK(not pr::expect(pr::Charset{'a', 'd'})("e"));
+    CHECK(not pr::expect(pr::Charset{'a', 'd'})("f"));
+    CHECK(not pr::expect(pr::Charset{'a', 'd'})("g"));
+    CHECK(not pr::expect(pr::Charset{'a', 'd'})("h"));
+
     CHECK(not pr::expect("test")(""));
     CHECK(not pr::expect('a')(""));
     CHECK(not pr::expect(pr::Charset("abcd"))(""));
+    CHECK(not pr::expect(pr::CharRange{'a', 'd'})(""));
 }
 
 TEST_CASE("expect dynamic string")


### PR DESCRIPTION
A new expect parser is added to cover the contiguous character range cases.

There are no solutions in this PR for small charsets.

issue #65